### PR TITLE
Removed the dependencies from cuda ep dll

### DIFF
--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_allocator.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_allocator.cc
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "nv_allocator.h"
+#include "nv_includes.h"
+#include "core/providers/cuda/shared_inc/cuda_call.h"
+namespace onnxruntime {
+
+void CUDAAllocator::CheckDevice(bool throw_when_fail) const {
+#ifndef NDEBUG
+  // check device to match at debug build
+  // if it's expected to change, call cudaSetDevice instead of the check
+  int current_device;
+  auto cuda_err = cudaGetDevice(&current_device);
+  if (cuda_err == cudaSuccess) {
+    ORT_ENFORCE(current_device == Info().id);
+  } else if (throw_when_fail) {
+    CUDA_CALL_THROW(cuda_err);
+  }
+#else
+  ORT_UNUSED_PARAMETER(throw_when_fail);
+#endif
+}
+
+void CUDAAllocator::SetDevice(bool throw_when_fail) const {
+  int current_device;
+  auto cuda_err = cudaGetDevice(&current_device);
+  if (cuda_err == cudaSuccess) {
+    int allocator_device_id = Info().id;
+    if (current_device != allocator_device_id) {
+      cuda_err = cudaSetDevice(allocator_device_id);
+    }
+  }
+
+  if (cuda_err != cudaSuccess && throw_when_fail) {
+    CUDA_CALL_THROW(cuda_err);
+  }
+}
+
+void* CUDAAllocator::Alloc(size_t size) {
+  SetDevice(true);
+  CheckDevice(true);
+  void* p = nullptr;
+  if (size > 0) {
+    // BFCArena was updated recently to handle the exception and adjust the request size
+    CUDA_CALL_THROW(cudaMalloc((void**)&p, size));
+  }
+  return p;
+}
+
+void CUDAAllocator::Free(void* p) {
+  SetDevice(false);
+  CheckDevice(false);  // ignore CUDA failure when free
+  cudaFree(p);         // do not throw error since it's OK for cudaFree to fail during shutdown
+}
+
+void* CUDAExternalAllocator::Alloc(size_t size) {
+  void* p = nullptr;
+  if (size > 0) {
+    p = alloc_(size);
+
+    // review(codemzs): ORT_ENFORCE does not seem appropriate.
+    ORT_ENFORCE(p != nullptr);
+  }
+
+  return p;
+}
+
+void CUDAExternalAllocator::Free(void* p) {
+  free_(p);
+  std::lock_guard<std::mutex> lock(lock_);
+  auto it = reserved_.find(p);
+  if (it != reserved_.end()) {
+    reserved_.erase(it);
+    if (empty_cache_) empty_cache_();
+  }
+}
+
+void* CUDAExternalAllocator::Reserve(size_t size) {
+  void* p = Alloc(size);
+  if (!p) return nullptr;
+  std::lock_guard<std::mutex> lock(lock_);
+  ORT_ENFORCE(reserved_.find(p) == reserved_.end());
+  reserved_.insert(p);
+  return p;
+}
+
+void* CUDAPinnedAllocator::Alloc(size_t size) {
+  void* p = nullptr;
+  if (size > 0) {
+    CUDA_CALL_THROW(cudaMallocHost((void**)&p, size));
+  }
+  return p;
+}
+
+void CUDAPinnedAllocator::Free(void* p) {
+  CUDA_CALL_THROW(cudaFreeHost(p));
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_allocator.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_allocator.h
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // Licensed under the MIT License.
 
 #pragma once

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_allocator.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_allocator.h
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/inlined_containers.h"
+#include "core/framework/allocator.h"
+#include <mutex>
+
+namespace onnxruntime {
+
+class CUDAAllocator : public IAllocator {
+ public:
+  CUDAAllocator(OrtDevice::DeviceId device_id, const char* name)
+      : IAllocator(
+            OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
+                          OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, device_id),
+                          device_id, OrtMemTypeDefault)) {}
+  void* Alloc(size_t size) override;
+  void Free(void* p) override;
+
+ private:
+  void CheckDevice(bool throw_when_fail) const;
+  void SetDevice(bool throw_when_fail) const;
+};
+
+class CUDAExternalAllocator : public CUDAAllocator {
+  typedef void* (*ExternalAlloc)(size_t size);
+  typedef void (*ExternalFree)(void* p);
+  typedef void (*ExternalEmptyCache)();
+
+ public:
+  CUDAExternalAllocator(OrtDevice::DeviceId device_id, const char* name, void* alloc, void* free, void* empty_cache)
+      : CUDAAllocator(device_id, name) {
+    alloc_ = reinterpret_cast<ExternalAlloc>(alloc);
+    free_ = reinterpret_cast<ExternalFree>(free);
+    empty_cache_ = reinterpret_cast<ExternalEmptyCache>(empty_cache);
+  }
+
+  void* Alloc(size_t size) override;
+  void Free(void* p) override;
+  void* Reserve(size_t size) override;
+
+ private:
+  mutable std::mutex lock_;
+  ExternalAlloc alloc_;
+  ExternalFree free_;
+  ExternalEmptyCache empty_cache_;
+  InlinedHashSet<void*> reserved_;
+};
+
+// TODO: add a default constructor
+class CUDAPinnedAllocator : public IAllocator {
+ public:
+  CUDAPinnedAllocator(const char* name)
+      : IAllocator(
+            OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
+                          OrtDevice(OrtDevice::CPU, OrtDevice::MemType::CUDA_PINNED, 0 /*CPU device always with id 0*/),
+                          0, OrtMemTypeCPUOutput)) {}
+
+  void* Alloc(size_t size) override;
+  void Free(void* p) override;
+};
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_cuda_call.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_cuda_call.cc
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // Licensed under the MIT License.
 
 #include "core/providers/shared_library/provider_api.h"
@@ -137,7 +138,6 @@ std::conditional_t<THRW, void, Status> CudaCall(
     return Status::OK();
   }
 }
-
 
 template Status CudaCall<cudaError, false>(cudaError retCode, const char* exprString, const char* libName, cudaError successCode, const char* msg, const char* file, const int line);
 template void CudaCall<cudaError, true>(cudaError retCode, const char* exprString, const char* libName, cudaError successCode, const char* msg, const char* file, const int line);

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_cuda_call.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_cuda_call.cc
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/shared_library/provider_api.h"
+#include "core/providers/cuda/shared_inc/cuda_call.h"
+#include <core/platform/env.h>
+
+#ifdef _WIN32
+#else  // POSIX
+#include <unistd.h>
+#include <string.h>
+#endif
+
+namespace onnxruntime {
+
+using namespace common;
+
+template <typename ERRTYPE>
+const char* CudaErrString(ERRTYPE) {
+  ORT_NOT_IMPLEMENTED();
+}
+
+#define CASE_ENUM_TO_STR(x) \
+  case x:                   \
+    return #x
+
+template <>
+const char* CudaErrString<cudaError_t>(cudaError_t x) {
+  cudaDeviceSynchronize();
+  return cudaGetErrorString(x);
+}
+
+#ifndef USE_CUDA_MINIMAL
+template <>
+const char* CudaErrString<cublasStatus_t>(cublasStatus_t e) {
+  cudaDeviceSynchronize();
+  switch (e) {
+    CASE_ENUM_TO_STR(CUBLAS_STATUS_SUCCESS);
+    CASE_ENUM_TO_STR(CUBLAS_STATUS_NOT_INITIALIZED);
+    CASE_ENUM_TO_STR(CUBLAS_STATUS_ALLOC_FAILED);
+    CASE_ENUM_TO_STR(CUBLAS_STATUS_INVALID_VALUE);
+    CASE_ENUM_TO_STR(CUBLAS_STATUS_ARCH_MISMATCH);
+    CASE_ENUM_TO_STR(CUBLAS_STATUS_MAPPING_ERROR);
+    CASE_ENUM_TO_STR(CUBLAS_STATUS_EXECUTION_FAILED);
+    CASE_ENUM_TO_STR(CUBLAS_STATUS_INTERNAL_ERROR);
+    CASE_ENUM_TO_STR(CUBLAS_STATUS_NOT_SUPPORTED);
+    CASE_ENUM_TO_STR(CUBLAS_STATUS_LICENSE_ERROR);
+    default:
+      return "(look for CUBLAS_STATUS_xxx in cublas_api.h)";
+  }
+}
+
+template <>
+const char* CudaErrString<curandStatus>(curandStatus) {
+  cudaDeviceSynchronize();
+  return "(see curand.h & look for curandStatus or CURAND_STATUS_xxx)";
+}
+
+template <>
+const char* CudaErrString<cudnnStatus_t>(cudnnStatus_t e) {
+  cudaDeviceSynchronize();
+  return cudnnGetErrorString(e);
+}
+
+template <>
+const char* CudaErrString<cufftResult>(cufftResult e) {
+  cudaDeviceSynchronize();
+  switch (e) {
+    CASE_ENUM_TO_STR(CUFFT_SUCCESS);
+    CASE_ENUM_TO_STR(CUFFT_ALLOC_FAILED);
+    CASE_ENUM_TO_STR(CUFFT_INVALID_VALUE);
+    CASE_ENUM_TO_STR(CUFFT_INTERNAL_ERROR);
+    CASE_ENUM_TO_STR(CUFFT_SETUP_FAILED);
+    CASE_ENUM_TO_STR(CUFFT_INVALID_SIZE);
+    default:
+      return "Unknown cufft error status";
+  }
+}
+#endif
+
+#ifdef ORT_USE_NCCL
+template <>
+const char* CudaErrString<ncclResult_t>(ncclResult_t e) {
+  cudaDeviceSynchronize();
+  return ncclGetErrorString(e);
+}
+#endif
+
+template <typename ERRTYPE>
+int GetErrorCode(ERRTYPE err) {
+  return static_cast<int>(err);
+}
+
+template <typename ERRTYPE, bool THRW, typename SUCCTYPE>
+std::conditional_t<THRW, void, Status> CudaCall(
+    ERRTYPE retCode, const char* exprString, const char* libName, SUCCTYPE successCode, const char* msg,
+    const char* file, const int line) {
+  if (retCode != successCode) {
+    try {
+#ifdef _WIN32
+      std::string hostname_str = GetEnvironmentVar("COMPUTERNAME");
+      if (hostname_str.empty()) {
+        hostname_str = "?";
+      }
+      const char* hostname = hostname_str.c_str();
+#else
+      char hostname[HOST_NAME_MAX];
+      if (gethostname(hostname, HOST_NAME_MAX) != 0)
+        strcpy(hostname, "?");
+#endif
+      int currentCudaDevice = -1;
+      cudaGetDevice(&currentCudaDevice);
+      cudaGetLastError();  // clear last CUDA error
+      static char str[1024];
+      snprintf(str, 1024, "%s failure %d: %s ; GPU=%d ; hostname=%s ; file=%s ; line=%d ; expr=%s; %s",
+               libName, GetErrorCode(retCode), CudaErrString(retCode), currentCudaDevice,
+               hostname,
+               file, line, exprString, msg);
+      if constexpr (THRW) {
+        // throw an exception with the error info
+        ORT_THROW(str);
+      } else {
+        LOGS_DEFAULT(ERROR) << str;
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, str);
+      }
+    } catch (const std::exception& e) {  // catch, log, and rethrow since CUDA code sometimes hangs in destruction,
+                                         // so we'd never get to see the error
+      if constexpr (THRW) {
+        ORT_THROW(e.what());
+      } else {
+        LOGS_DEFAULT(ERROR) << e.what();
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+      }
+    }
+  }
+  if constexpr (!THRW) {
+    return Status::OK();
+  }
+}
+
+
+template Status CudaCall<cudaError, false>(cudaError retCode, const char* exprString, const char* libName, cudaError successCode, const char* msg, const char* file, const int line);
+template void CudaCall<cudaError, true>(cudaError retCode, const char* exprString, const char* libName, cudaError successCode, const char* msg, const char* file, const int line);
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_data_transfer.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_data_transfer.cc
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // Licensed under the MIT License.
 
 #include "core/providers/shared_library/provider_api.h"

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_data_transfer.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_data_transfer.cc
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/shared_library/provider_api.h"
+
+#include "nv_data_transfer.h"
+
+#include "core/providers/cuda/shared_inc/cuda_call.h"
+#define CUDA_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(CUDA_CALL(expr))
+namespace onnxruntime {
+bool GPUDataTransfer::CanCopy(const OrtDevice& src_device, const OrtDevice& dst_device) const {
+  return src_device.Type() == OrtDevice::GPU || src_device.MemType() == OrtDevice::MemType::CUDA_PINNED ||
+         dst_device.Type() == OrtDevice::GPU || dst_device.MemType() == OrtDevice::MemType::CUDA_PINNED;
+}
+
+common::Status GPUDataTransfer::CopyTensor(const Tensor& src, Tensor& dst) const {
+  size_t bytes = src.SizeInBytes();
+  const void* src_data = src.DataRaw();
+  void* dst_data = dst.MutableDataRaw();
+
+  auto& src_device = src.Location().device;
+  auto& dst_device = dst.Location().device;
+
+  // for the sync version of memcpy, launch to cuda default stream
+  if (dst_device.Type() == OrtDevice::GPU) {
+    if (src_device.Type() == OrtDevice::GPU) {
+      // Copy only if the two addresses are different.
+      if (dst_data != src_data) {
+        CUDA_RETURN_IF_ERROR(cudaMemcpy(dst_data, src_data, bytes, cudaMemcpyDeviceToDevice));
+        // For device memory to device memory copy, no host-side synchronization is performed by cudaMemcpy.
+        // see https://docs.nvidia.com/cuda/cuda-runtime-api/api-sync-behavior.html
+        CUDA_RETURN_IF_ERROR(cudaStreamSynchronize(nullptr));
+      }
+    } else {
+      // copy from other CPU memory to GPU, this is blocking
+      CUDA_RETURN_IF_ERROR(cudaMemcpy(dst_data, src_data, bytes, cudaMemcpyHostToDevice));
+      if (src_device.MemType() != OrtDevice::MemType::CUDA_PINNED) {
+        // For cudaMemcpy from pageable host memory to device memory, DMA to final destination may not have completed.
+        // see https://docs.nvidia.com/cuda/cuda-runtime-api/api-sync-behavior.html
+        CUDA_RETURN_IF_ERROR(cudaStreamSynchronize(nullptr));
+      }
+    }
+  } else if (src_device.Type() == OrtDevice::GPU) {
+    // copying from GPU to CPU memory, this is blocking
+    CUDA_RETURN_IF_ERROR(cudaMemcpy(dst_data, src_data, bytes, cudaMemcpyDeviceToHost));
+  } else {
+    // copying between cpu memory
+    ORT_ENFORCE(dst_data != src_data);
+    memcpy(dst_data, src_data, bytes);
+  }
+
+  return Status::OK();
+}
+
+common::Status GPUDataTransfer::CopyTensorAsync(const Tensor& src, Tensor& dst, Stream& stream) const {
+  size_t bytes = src.SizeInBytes();
+  const void* src_data = src.DataRaw();
+  void* dst_data = dst.MutableDataRaw();
+
+  auto& src_device = src.Location().device;
+  auto& dst_device = dst.Location().device;
+
+  if (dst_device.Type() == OrtDevice::GPU) {
+    if (src_device.Type() == OrtDevice::CPU) {
+      // copy from pinned or non-pinned CPU memory to GPU
+      CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(dst_data, src_data, bytes, cudaMemcpyHostToDevice, static_cast<cudaStream_t>(stream.GetHandle())));
+    } else if (src_device.Type() == OrtDevice::GPU) {
+      // copying between GPU, this is non-blocking
+      if (dst_data != src_data) {
+        CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(dst_data, src_data, bytes, cudaMemcpyDeviceToDevice, static_cast<cudaStream_t>(stream.GetHandle())));
+      }
+    }
+  } else if (src_device.Type() == OrtDevice::GPU) {
+    if (dst_device.Type() == OrtDevice::CPU) {
+      // copy from GPU to pinned or non-pinned CPU memory.
+      CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(dst_data, src_data, bytes, cudaMemcpyDeviceToHost, static_cast<cudaStream_t>(stream.GetHandle())));
+    }
+  } else {
+    if (src_device.MemType() == OrtDevice::MemType::CUDA_PINNED) {
+      // sync the stream first to make sure the data arrived
+      CUDA_RETURN_IF_ERROR(cudaStreamSynchronize(static_cast<cudaStream_t>(stream.GetHandle())));
+    }
+
+    ORT_ENFORCE(dst_data != src_data);
+    memcpy(dst_data, src_data, bytes);
+  }
+
+  return Status::OK();
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_data_transfer.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_data_transfer.h
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // Licensed under the MIT License.
 
 #pragma once

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_data_transfer.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_data_transfer.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "nv_includes.h"
+#include "core/framework/data_transfer.h"
+
+namespace onnxruntime {
+
+class GPUDataTransfer : public IDataTransfer {
+ public:
+  GPUDataTransfer() = default;
+  ~GPUDataTransfer() = default;
+
+  bool CanCopy(const OrtDevice& src_device, const OrtDevice& dst_device) const override;
+
+  // Dumpen MSVC warning about not fully overriding
+  using IDataTransfer::CopyTensor;
+  common::Status CopyTensor(const Tensor& src, Tensor& dst) const override;
+  common::Status CopyTensorAsync(const Tensor& src, Tensor& dst, Stream& stream) const override;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // Licensed under the MIT License.
 #include <fstream>
 #include <list>

--- a/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
+++ b/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
@@ -347,7 +347,7 @@ common::Status IExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>&
   return g_host->IExecutionProvider__Compile(this, fused_nodes_and_graphs, node_compute_funcs);
 }
 
-#if defined(USE_TENSORRT) || defined(USE_NV)
+#if defined(USE_TENSORRT)
 std::unique_ptr<IAllocator> CreateCUDAAllocator(int16_t device_id, const char* name) {
   return g_host->CreateCUDAAllocator(device_id, name);
 }

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -2189,7 +2189,7 @@ def main():
 
     cmake_extra_defines = normalize_arg_list(args.cmake_extra_defines)
 
-    if args.use_tensorrt or args.use_nv_tensorrt_rtx:
+    if args.use_tensorrt:
         args.use_cuda = True
 
     if args.build_wheel or args.gen_doc or args.enable_training:


### PR DESCRIPTION


### Description
<!-- Describe your changes. -->
1. Copied the CUDA allocator implementation from CUDA EP to the NV
2. Copied data transfer implementation from CUDA EP to NV
3. Copied the CUDA error handling in NV


### Motivation and Context
In WCR, onnxruntime.dll is located at, for example, /wcr/onnxruntime.dll, while onnxruntime_providers_nv_tensorrt_rtx.dll resides in /wcr/nv/onnxruntime_providers_nv_tensorrt_rtx.dll. These libraries are loaded using absolute paths, and their dependencies—such as nvinfer.dll—are correctly resolved from the /wcr/nv/ directory. However, the issue arises when onnxruntime_providers_cuda.dll is loaded dynamically at runtime. In this case, the system attempts to locate it in the application directory (e.g., /app/Photoshop.exe) or possibly in /wcr, but it does not search in /wcr/nv/, leading to unresolved dependencies.




